### PR TITLE
Add a new front controller to nginx configuration file "silex.conf"

### DIFF
--- a/nginx/1.0/conf/silex.conf
+++ b/nginx/1.0/conf/silex.conf
@@ -7,7 +7,7 @@ server {
         try_files $uri /index.php$is_args$args;
     }
 
-    location ~ ^/(index|index_dev|index_test)\.php(/|$) {
+    location ~ ^/(index|index_dev|index_test|index_test_cloud)\.php(/|$) {
         fastcgi_pass php:9000;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;

--- a/nginx/1.1/conf/silex.conf
+++ b/nginx/1.1/conf/silex.conf
@@ -7,7 +7,7 @@ server {
         try_files $uri /index.php$is_args$args;
     }
 
-    location ~ ^/(index|index_dev|index_test)\.php(/|$) {
+    location ~ ^/(index|index_dev|index_test|index_test_cloud)\.php(/|$) {
         fastcgi_pass php:9000;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;


### PR DESCRIPTION
Add a new front controller "index_test_cloud.php" to the allowed controller in the nginx configuration for silex. This is required to test the cloud infra in the static project.