### PR TITLE
Docker: Ajout du container noVnc

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!--
+COMMITTERS:
+- Le titre doit suivre : <type>(scope): <verb> + message
+- Ajouter une description.
+- Placer le tag bug sur les PR de support
+- Lire http://red.cospirit.com:8060/projects/ar-developpement/wiki/Utiliser_GIT_-_HOWTO#Format-des-commits-et-des-pull-requests
+-->
+
+## Description
+<!--
+Décrire précisément la fonctionnalité apportée par cette demande de modification
+ou le bug qu'elle corrige.
+La description doit être claire et précise afin que la review soit efficace.
+-->
+
+## Change log
+<!--Mon message pour le change log-->
+
+## Links
+**Ticket Youtrack :**
+ - <Le(s) ticket(s) YouTrack concerné(s)>
+
+**PRs liées :**
+ - <Mes Pull Requests liées>
+
+## Procédure de recette
+<!--
+Décrire la procédure pour recetter les modifications apportées par la pull request
+-->

--- a/novnc/1.0/Dockerfile
+++ b/novnc/1.0/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:3.6
+LABEL maintainer=doug.warren@gmail.com
+
+ENV HOME=/root \
+	DEBIAN_FRONTEND=noninteractive \
+	LANG=en_US.UTF-8 \
+	LANGUAGE=en_US.UTF-8 \
+	LC_ALL=C.UTF-8 \
+	REMOTE_HOST=localhost \
+	REMOTE_PORT=5900
+
+RUN apk --update --upgrade add git bash supervisor nodejs nodejs-npm \
+	&& git clone https://github.com/novnc/noVNC.git /root/noVNC \
+	&& git clone https://github.com/novnc/websockify /root/noVNC/utils/websockify \
+	&& rm -rf /root/noVNC/.git \
+	&& rm -rf /root/noVNC/utils/websockify/.git \
+	&& cd /root/noVNC \
+	&& npm install npm@latest \
+	&& npm install \
+	&& ./utils/use_require.js --as commonjs --with-app \
+	&& cp /root/noVNC/node_modules/requirejs/require.js /root/noVNC/build \
+	&& sed -i -- "s/ps -p/ps -o pid | grep/g" /root/noVNC/utils/launch.sh \
+	&& apk del git nodejs-npm nodejs
+
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+EXPOSE 8081
+
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/novnc/1.0/Dockerfile
+++ b/novnc/1.0/Dockerfile
@@ -18,7 +18,10 @@ RUN apk --update --upgrade add git bash supervisor nodejs nodejs-npm \
 	&& npm install npm@latest \
 	&& npm install \
 	&& ./utils/use_require.js --as commonjs --with-app \
-	&& cp /root/noVNC/node_modules/requirejs/require.js /root/noVNC/build \
+	&& cp /root/noVNC/node_modules/requirejs/require.js /root/noVNC/build
+
+RUN cd /root/noVNC/build \
+	&& ln -s /root/noVNC/build/vnc.html index.html \
 	&& sed -i -- "s/ps -p/ps -o pid | grep/g" /root/noVNC/utils/launch.sh \
 	&& apk del git nodejs-npm nodejs
 

--- a/novnc/1.0/Dockerfile
+++ b/novnc/1.0/Dockerfile
@@ -7,7 +7,9 @@ ENV HOME=/root \
 	LANGUAGE=en_US.UTF-8 \
 	LC_ALL=C.UTF-8 \
 	REMOTE_HOST=localhost \
-	REMOTE_PORT=5900
+	REMOTE_PORT=5900 \
+	STDOUT_LOGFILE=/dev/stdout \
+	STDOUT_LOGFILE_MAXBYTES=0
 
 RUN apk --update --upgrade add git bash supervisor nodejs nodejs-npm \
 	&& git clone https://github.com/novnc/noVNC.git /root/noVNC \
@@ -20,6 +22,7 @@ RUN apk --update --upgrade add git bash supervisor nodejs nodejs-npm \
 	&& ./utils/use_require.js --as commonjs --with-app \
 	&& cp /root/noVNC/node_modules/requirejs/require.js /root/noVNC/build
 
+# We add a symlink in order to access the home page directly on "/"
 RUN cd /root/noVNC/build \
 	&& ln -s /root/noVNC/build/vnc.html index.html \
 	&& sed -i -- "s/ps -p/ps -o pid | grep/g" /root/noVNC/utils/launch.sh \

--- a/novnc/1.0/README.md
+++ b/novnc/1.0/README.md
@@ -4,15 +4,18 @@ This image is intended to run a small standalone server that can target either o
 
 ## Configuration
 
-Two environment variables exist in the docker file for configuration REMOTE_HOST and REMOTE_PORT.
+Two environment variables exist in the docker file for configuration `REMOTE_HOST` and `REMOTE_PORT`.
 
 ### Variables
 
-!! Ces variables ne fonctionnent pas, car le fichier launch.sh, les utilisant, 
-ne les prend pas en compte !!
+ > **Bug** : ***Those env variables don't work because the `launch.sh`, using them, 
+ nothing happen on the client side***
+
 
 **REMOTE_HOST** Host running a VNC Server to connect to - defaults to *localhost*
 **REMOTE_PORT** Port that the VNC Server is listening on - defaults to *5900* 
+**STDOUT_LOGFILE** 
+**STDOUT_LOGFILE_MAXBYTES**
 
 ### Ports
 **8081** is exposed by default.

--- a/novnc/1.0/README.md
+++ b/novnc/1.0/README.md
@@ -8,8 +8,11 @@ Two environment variables exist in the docker file for configuration REMOTE_HOST
 
 ### Variables
 
+!! Ces variables ne fonctionnent pas, car le fichier launch.sh, les utilisant, 
+ne les prend pas en compte !!
+
 **REMOTE_HOST** Host running a VNC Server to connect to - defaults to *localhost*
-**REMOTE_PORT** Port that the VNC Server is listening on - defaults to *5900*
+**REMOTE_PORT** Port that the VNC Server is listening on - defaults to *5900* 
 
 ### Ports
 **8081** is exposed by default.

--- a/novnc/1.0/README.md
+++ b/novnc/1.0/README.md
@@ -1,0 +1,21 @@
+# Standalone NoVNC Container
+
+This image is intended to run a small standalone server that can target either other machines on the same network or other Docker containers.
+
+## Configuration
+
+Two environment variables exist in the docker file for configuration REMOTE_HOST and REMOTE_PORT.
+
+### Variables
+
+**REMOTE_HOST** Host running a VNC Server to connect to - defaults to *localhost*
+**REMOTE_PORT** Port that the VNC Server is listening on - defaults to *5900*
+
+### Ports
+**8081** is exposed by default.
+
+## Usage
+
+```
+docker run -d -e REMOTE_HOST=192.168.86.135 -e REMOTE_PORT=5901 dougw/novnc
+```

--- a/novnc/1.0/README.md
+++ b/novnc/1.0/README.md
@@ -14,8 +14,8 @@ Two environment variables exist in the docker file for configuration `REMOTE_HOS
 
 **REMOTE_HOST** Host running a VNC Server to connect to - defaults to *localhost*
 **REMOTE_PORT** Port that the VNC Server is listening on - defaults to *5900* 
-**STDOUT_LOGFILE** 
-**STDOUT_LOGFILE_MAXBYTES**
+**STDOUT_LOGFILE** Log file output for supervisord
+**STDOUT_LOGFILE_MAXBYTES** Log file size output, set to 0 in order to avoid an error
 
 ### Ports
 **8081** is exposed by default.

--- a/novnc/1.0/supervisord.conf
+++ b/novnc/1.0/supervisord.conf
@@ -1,0 +1,6 @@
+[supervisord]
+nodaemon=true
+
+[program:novnc]
+command=/root/noVNC/utils/launch.sh --vnc "%(ENV_REMOTE_HOST)s:%(ENV_REMOTE_PORT)s" --listen 8081 --web /root/noVNC/build/
+autorestart=true

--- a/novnc/1.0/supervisord.conf
+++ b/novnc/1.0/supervisord.conf
@@ -3,6 +3,6 @@ nodaemon=true
 
 [program:novnc]
 command=/root/noVNC/utils/launch.sh --vnc "%(ENV_REMOTE_HOST)s:%(ENV_REMOTE_PORT)s" --listen 8081 --web /root/noVNC/build/
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
+stdout_logfile="%(STDOUT_LOGFILE)s"
+stdout_logfile_maxbytes="%(STDOUT_LOGFILE_MAXBYTES)s"
 autorestart=true

--- a/novnc/1.0/supervisord.conf
+++ b/novnc/1.0/supervisord.conf
@@ -3,6 +3,6 @@ nodaemon=true
 
 [program:novnc]
 command=/root/noVNC/utils/launch.sh --vnc "%(ENV_REMOTE_HOST)s:%(ENV_REMOTE_PORT)s" --listen 8081 --web /root/noVNC/build/
-stdout_logfile="%(STDOUT_LOGFILE)s"
-stdout_logfile_maxbytes="%(STDOUT_LOGFILE_MAXBYTES)s"
+stdout_logfile=%(ENV_STDOUT_LOGFILE)s
+stdout_logfile_maxbytes=%(ENV_STDOUT_LOGFILE_MAXBYTES)s
 autorestart=true

--- a/novnc/1.0/supervisord.conf
+++ b/novnc/1.0/supervisord.conf
@@ -3,4 +3,6 @@ nodaemon=true
 
 [program:novnc]
 command=/root/noVNC/utils/launch.sh --vnc "%(ENV_REMOTE_HOST)s:%(ENV_REMOTE_PORT)s" --listen 8081 --web /root/noVNC/build/
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 autorestart=true


### PR DESCRIPTION
<!--
COMMITTERS:
- Le titre doit suivre : <type>(scope): <verb> + message
- Ajouter une description.
- Placer le tag bug sur les PR de support
- Lire http://red.cospirit.com:8060/projects/ar-developpement/wiki/Utiliser_GIT_-_HOWTO#Format-des-commits-et-des-pull-requests
-->

## Description
Ajout de la nouvelle docker novnc afin de pouvoir se connecter sur une autre docker executant les tests selenium via behat

## Change log
Ajout de docker novnc

## Links
**Ticket Youtrack :**
 - https://cospirit.myjetbrains.com/youtrack/issue/connect-1219

## Documentation
 - [Les tests selenium](https://cospirit-connect.gitbook.io/integration-continue/tests-fonctionnels/untitled/les-tests-avec-selenium)
 - [Les tests behat](https://cospirit-connect.gitbook.io/integration-continue/tests-fonctionnels/untitled)
 - [La docker noVnc](https://cospirit-connect.gitbook.io/infrastructure/les-containers-dockers/novnc)
 - [La docker Chrome selenium](https://cospirit-connect.gitbook.io/infrastructure/les-containers-dockers/chrome-selenium)

## Procédure de recette
- Créer un nouveau dossier
- Ajouter un nouveau `docker-compose.yml`
- Copier ce contenu dans ce fichier `docker-compose.yml`
```
version: '2'

services:
  # Config permettant de lancer le client novnc
  novnc:
      # Ajouter votre nom d'image
      image: votre_image_novnc_image:latest

      ports:
          - "6080:8081"
  # Config permettant de build l'image utilisé par 'novnc'
  novnc_image:
      # Ajouter votre propre chemin de 'ArDeveloppement/docker-images'
      build: /www/docker-images/novnc/1.0

```
- Faire un build du dockerfile : `docker-compose build --no-cache novnc_image`
- Lancer le container : `docker-compose up novnc`
- Ouvrir l'application l'adresse 127.0.0.1:6080

![image](https://user-images.githubusercontent.com/881943/52415422-3403ff80-2ae7-11e9-8bf1-917a6710b6f2.png)
